### PR TITLE
После tflint и checkov исправил ошибки

### DIFF
--- a/SRC/1-3/main.tf
+++ b/SRC/1-3/main.tf
@@ -2,7 +2,13 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "~>0.44.0"
     }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.0"
+    }
+
   }
   required_version = ">=0.13"
 
@@ -42,7 +48,7 @@ module "vpc_dev" {
 
 
 module "test-vm" {
-  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=95c286e"
   env_name        = "develop"
   network_id      = module.vpc_dev.network_id
   subnet_zones    = ["ru-central1-a"]

--- a/SRC/1-3/variables.tf
+++ b/SRC/1-3/variables.tf
@@ -19,17 +19,7 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
 
-variable "vpc_name" {
-  type        = string
-  default     = "develop"
-  description = "VPC network&subnet name"
-}
 
 variable "ssh-authorized-keys" {
   description = "Path to public SSH key file"


### PR DESCRIPTION
5 issue(s) found:

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on main.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_required_providers.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 45:
  45:   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on main.tf line 63:
  63: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "default_cidr" is declared but not used (terraform_unused_declarations)

  on variables.tf line 22:
  22: variable "default_cidr" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vpc_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 28:
  28: variable "vpc_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md


Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: test-vm
        File: /main.tf:44-60
        Guide: https://docs.paloaltonetworks.com/content/techdocs/en_US/prisma/prisma-cloud/prisma-cloud-code-security-policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision.html

                44 | module "test-vm" {
                45 |   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
                46 |   env_name        = "develop"
                47 |   network_id      = module.vpc_dev.network_id
                48 |   subnet_zones    = ["ru-central1-a"]
                49 |   subnet_ids      = [module.vpc_dev.subnet_id]
                50 |   instance_name   = "web"
                51 |   instance_count  = 1
                52 |   image_family    = "ubuntu-2004-lts"
                53 |   public_ip       = true
                54 | 
                55 |   metadata = {
                56 |       user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
                57 |       serial-port-enable = 1
                58 |   }
                59 | 
                60 | }

